### PR TITLE
plus sticky footer with resume button and contact handlers

### DIFF
--- a/pr17-app/src/components/layout/MainLayout.js
+++ b/pr17-app/src/components/layout/MainLayout.js
@@ -1,15 +1,13 @@
 import React from 'react';
-import { Box } from '@mui/material';
 import StickyHeader from './StickyHeader';
 import MuiBreadCrumbs from '../breadcrumbs/MuiBreadCrumbs';
+import StickyFooter from './StickyFooter';
 
 const MainLayout = ({ children }) => (
   <div>
     <StickyHeader />
     <MuiBreadCrumbs />
-    <Box sx={{ backgroundColor: 'background.default', padding: 2, height: '100vh', display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center' }}>
-      {children}
-    </Box>
+    <StickyFooter>{children}</StickyFooter>
   </div>
 );
 

--- a/pr17-app/src/components/layout/StickyFooter.js
+++ b/pr17-app/src/components/layout/StickyFooter.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Box } from '@mui/material';
+
+const StickyFooter = ({ children }) => (
+  <Box
+    sx={{
+      backgroundColor: 'background.default',
+      padding: 2,
+      height: '100vh',
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'center',
+      alignItems: 'center',
+    }}
+  >
+    {children}
+  </Box>
+);
+
+export default StickyFooter;

--- a/pr17-app/src/components/layout/contact/ContactSection.js
+++ b/pr17-app/src/components/layout/contact/ContactSection.js
@@ -1,12 +1,18 @@
 import ContactBoxPosition from './ContactBoxPosition';
 import ContactTabs from './ContactTabs';
-import { handleEmailClick, handleGitHubClick, handleLinkedInClick } from '../../../utils/contactHandlers';
+import {
+  handleResumeClick,
+  handleEmailClick,
+  handleGitHubClick,
+  handleLinkedInClick,
+} from '../../../hooks/useContactHandlers';
 
 const ContactSection = ({ value, handleChange }) => (
   <ContactBoxPosition>
     <ContactTabs
       value={value}
       handleChange={handleChange}
+      handleResumeClick={handleResumeClick}
       handleEmailClick={handleEmailClick}
       handleGitHubClick={handleGitHubClick}
       handleLinkedInClick={handleLinkedInClick}

--- a/pr17-app/src/components/layout/contact/ContactTabs.js
+++ b/pr17-app/src/components/layout/contact/ContactTabs.js
@@ -4,8 +4,16 @@ import ContactTab from './ContactTab';
 import LinkedInIcon from '@mui/icons-material/LinkedIn';
 import GitHubIcon from '@mui/icons-material/GitHub';
 import EmailIcon from '@mui/icons-material/Email';
+import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 
-const ContactTabs = ({ value, handleChange, handleEmailClick, handleGitHubClick, handleLinkedInClick }) => (
+const ContactTabs = ({
+  value,
+  handleChange,
+  handleResumeClick,
+  handleEmailClick,
+  handleGitHubClick,
+  handleLinkedInClick,
+}) => (
   <Stack direction="column" spacing={1} alignItems="center">
     <Tabs
       value={value}
@@ -13,9 +21,26 @@ const ContactTabs = ({ value, handleChange, handleEmailClick, handleGitHubClick,
       aria-label="contact tabs"
       sx={{ '& .MuiTabs-indicator': { display: 'none' } }}
     >
-      <ContactTab icon={<LinkedInIcon />} label="LinkedIn" onClick={handleLinkedInClick} />
-      <ContactTab icon={<GitHubIcon />} label="GitHub" onClick={handleGitHubClick} />
-      <ContactTab icon={<EmailIcon />} label="Email" onClick={handleEmailClick} />
+      <ContactTab
+        icon={<LinkedInIcon />}
+        label="LinkedIn"
+        onClick={handleLinkedInClick}
+      />
+      <ContactTab
+        icon={<GitHubIcon />}
+        label="GitHub"
+        onClick={handleGitHubClick}
+      />
+      <ContactTab
+        icon={<EmailIcon />}
+        label="Email"
+        onClick={handleEmailClick}
+      />
+      <ContactTab
+        icon={<CloudDownloadIcon />}
+        label="Resume"
+        onClick={handleResumeClick}
+      />
     </Tabs>
   </Stack>
 );

--- a/pr17-app/src/hooks/useContactHandlers.js
+++ b/pr17-app/src/hooks/useContactHandlers.js
@@ -1,18 +1,25 @@
-const useContactHandlers = () => {
-    const handleEmailClick = () => {
-      window.location.href = 'mailto:pablo.rosas.0170@gmail.com';
-    };
-  
-    const handleGitHubClick = () => {
-      window.open('https://github.com/PabloRosas17', '_blank');
-    };
-  
-    const handleLinkedInClick = () => {
-      window.open('https://www.linkedin.com/in/PabloRosas17', '_blank');
-    };
-  
-    return { handleEmailClick, handleGitHubClick, handleLinkedInClick };
-  };
-  
-  export default useContactHandlers;
-  
+export const handleResumeClick = () => {
+  const resumeUrl =
+    'https://www.dropbox.com/scl/fi/evtynz1mn105sxd8yfo39/pablorosas_rs_fw.pdf?rlkey=o4ygcfgvn5dtm7pl6awnsv06c&st=76islsw0&dl=0';
+  window.open(resumeUrl, '_blank');
+};
+
+export const handleEmailClick = () => {
+  const email = 'pablo.rosas.0170@gmail.com';
+  const subject = 'Subject Text';
+  const body = 'Body Text';
+  const mailtoLink = `mailto:${email}?subject=${encodeURIComponent(
+    subject
+  )}&body=${encodeURIComponent(body)}`;
+  window.location.href = mailtoLink;
+};
+
+export const handleGitHubClick = () => {
+  const githubUrl = 'https://github.com/PabloRosas17';
+  window.open(githubUrl, '_blank');
+};
+
+export const handleLinkedInClick = () => {
+  const linkedinUrl = 'https://www.linkedin.com/in/PabloRosas17';
+  window.open(linkedinUrl, '_blank');
+};

--- a/pr17-app/src/pages/TimeLinePage.js
+++ b/pr17-app/src/pages/TimeLinePage.js
@@ -4,15 +4,19 @@ import { Stack } from '@mui/material';
 import TimeLineCard from '../components/cards/timeline/TimeLineCard';
 import timelineData from '../assets/data/timelineData';
 import useExpandable from '../hooks/useExpandable';
-import useContactHandlers from '../hooks/useContactHandlers';
 import MainLayout from '../components/layout/MainLayout';
 import ContactTabs from '../components/layout/contact/ContactTabs';
 import MuiAboutChip from '../components/about/MuiAboutChip';
+import {
+  handleResumeClick,
+  handleEmailClick,
+  handleGitHubClick,
+  handleLinkedInClick,
+} from '../hooks/useContactHandlers';
 
 const TimeLinePage = () => {
   const { expandedIndex, handleExpand } = useExpandable();
-  const { handleEmailClick, handleGitHubClick, handleLinkedInClick } = useContactHandlers();
-
+  
   return (
     <MainLayout>
       <Stack direction="column" spacing={4} sx={{ width: '100%', maxWidth: 1200 }}>
@@ -38,6 +42,7 @@ const TimeLinePage = () => {
         </Timeline>
       </Stack>
       <ContactTabs
+        handleResumeClick={handleResumeClick}
         handleLinkedInClick={handleLinkedInClick}
         handleGitHubClick={handleGitHubClick}
         handleEmailClick={handleEmailClick}

--- a/pr17-app/src/utils/contactHandlers.js
+++ b/pr17-app/src/utils/contactHandlers.js
@@ -1,3 +1,0 @@
-export const handleEmailClick = () => window.location.href = 'mailto:pablo.rosas.0170@gmail.com';
-export const handleGitHubClick = () => window.open('https://github.com/PabloRosas17', '_blank');
-export const handleLinkedInClick = () => window.open('https://www.linkedin.com/in/PabloRosas17', '_blank');


### PR DESCRIPTION
```Added StickyFooter component to display a sticky footer across pages.

Introduced a resume button in the footer for easy access to the resume.

Implemented contact handlers for email, GitHub, LinkedIn, and resume actions.

Updated MainLayout to include the StickyFooter component.

Enhanced ContactSection and ContactTabs to utilize new contact handlers.

Removed deprecated contactHandlers.js utility file.```